### PR TITLE
Handle localmode in specstore

### DIFF
--- a/lib/network.rb
+++ b/lib/network.rb
@@ -19,7 +19,9 @@ module Statsig
     end
 
     def post_helper(endpoint, body, retries = 0, backoff = 1)
-      return nil unless !@local_mode
+      if @local_mode
+        return nil, nil
+      end
       http = HTTP.headers(
         {"STATSIG-API-KEY" => @server_secret,
         "STATSIG-CLIENT-TIME" => (Time.now.to_f * 1000).to_i.to_s,

--- a/lib/spec_store.rb
+++ b/lib/spec_store.rb
@@ -127,7 +127,7 @@ module Statsig
       begin
         response, e = @network.post_helper('download_config_specs', JSON.generate({ 'sinceTime' => @last_config_sync_time }))
         if e.nil?
-          if process(JSON.parse(response.body))
+          if !response.nil? and process(JSON.parse(response.body))
             @init_reason = EvaluationReason::NETWORK
             @rules_updated_callback.call(response.body.to_s, @last_config_sync_time) unless response.body.nil? or @rules_updated_callback.nil?
           end

--- a/test/local_overrides_test.rb
+++ b/test/local_overrides_test.rb
@@ -9,8 +9,12 @@ class StatsigLocalOverridesTest < Minitest::Test
     super
     options = StatsigOptions.new()
     options.local_mode = true
-    Statsig.initialize("secret-local", options)
-    Statsig.initialize("secret-blah")
+    Statsig.initialize("secret-local", options, method(:error_callback))
+  end
+
+  def error_callback(e)
+    puts e
+    assert(false) # force fail if this is called
   end
 
   def teardown


### PR DESCRIPTION
when local_mode is enabled, it currently throws an exception from the sync thread because it tries to dereference the request body to json parse the response