### PR TITLE
Add threadpool and differentiate async/sync event logging

### DIFF
--- a/lib/statsig_driver.rb
+++ b/lib/statsig_driver.rb
@@ -94,7 +94,7 @@ class StatsigDriver
 
   def shutdown
     @shutdown = true
-    @logger.flush(true)
+    @logger.shutdown
     @evaluator.shutdown
   end
 

--- a/lib/statsig_driver.rb
+++ b/lib/statsig_driver.rb
@@ -115,7 +115,6 @@ class StatsigDriver
 
   def maybe_restart_background_threads
     @evaluator.maybe_restart_background_threads
-    @logger.maybe_restart_background_threads
   end
 
   private

--- a/lib/statsig_logger.rb
+++ b/lib/statsig_logger.rb
@@ -13,9 +13,11 @@ module Statsig
       @options = options
 
       @logging_pool = Concurrent::ThreadPoolExecutor.new(
-        min_threads: 3,
-        max_threads: 10,
-        max_queue: 100, # max jobs pending before we start dropping
+        min_threads: [2, Concurrent.processor_count].min,
+        max_threads: [2, Concurrent.processor_count].max,
+        # max jobs pending before we start dropping
+        max_queue:   [2, Concurrent.processor_count].max * 5,
+        fallback_policy: :discard,
       )
     end
 

--- a/lib/statsig_logger.rb
+++ b/lib/statsig_logger.rb
@@ -19,6 +19,8 @@ module Statsig
         max_queue:   [2, Concurrent.processor_count].max * 5,
         fallback_policy: :discard,
       )
+
+      @background_flush = periodic_flush
     end
 
     def log_event(event)
@@ -92,6 +94,7 @@ module Statsig
     end
 
     def shutdown
+      @background_flush&.exit
       @logging_pool.shutdown
       @logging_pool.wait_for_termination(timeout = 3)
       flush

--- a/statsig.gemspec
+++ b/statsig.gemspec
@@ -15,4 +15,5 @@ Gem::Specification.new do |s|
     s.add_runtime_dependency 'user_agent_parser', '~>2.7'
     s.add_runtime_dependency 'http', '>= 4.4', '< 6.0'
     s.add_runtime_dependency 'ip3country', '~>0.1'
+    s.add_runtime_dependency 'concurrent-ruby', '~>1.1'
 end

--- a/test/test_concurrency.rb
+++ b/test/test_concurrency.rb
@@ -55,7 +55,7 @@ class TestConcurrency < Minitest::Test
   def test_calling_apis_concurrently
     Statsig.initialize('secret-testcase', StatsigOptions.new(rulesets_sync_interval: 0.01, idlists_sync_interval: 0.01))
     threads = []
-    20.times do
+    200.times do
       threads << Thread.new do
         50.times do |i|
           user = StatsigUser.new({'userID' => "user_id_#{i}", 'email' => 'testuser@statsig.com'})
@@ -77,11 +77,14 @@ class TestConcurrency < Minitest::Test
           end
         end
     end
-    
+
     threads.each(&:join)
     Statsig.shutdown
 
-    assert_equal(11000, @@flushed_event_count)
+    # 110000 total, some will be discarded due to max concurrency
+    # A single server running the server SDK is unlikely to post 100000+ events/exposures in a matter of seconds
+    # This test is primarily concerned with ensuring there are no deadlocks or exceptions from concurrent access
+    assert_operator 100000, :<, @@flushed_event_count
   end
 
   def teardown

--- a/test/test_logging.rb
+++ b/test/test_logging.rb
@@ -37,10 +37,7 @@ class TestLogging < Minitest::Test
     logger = Statsig::StatsigLogger.new(net, StatsigOptions.new)
     logger.log_event(StatsigEvent.new("my_event"))
 
-    spy = Spy.on(Thread, :new)
     logger.flush
-    spy.calls.first.block.call()
-    Spy.off(Thread, :new)
 
     assert_equal([500, 202], codes)
     assert_equal(0, logger.instance_variable_get("@events").length)
@@ -117,10 +114,7 @@ class TestLogging < Minitest::Test
       Statsig::ConfigResult.new('test_layer', evaluation_details: network_eval)
     )
 
-    thread_spy = Spy.on(Thread, :new)
     logger.flush
-    thread_spy.calls.first.block.call()
-    Spy.off(Thread, :new)
 
     events = spy.calls[0].args[0]
     assert_instance_of(Array, events)


### PR DESCRIPTION
use a threadpool when flush() is triggered from the main thread (via a gate check or log event)

leave shutdown() as a synchronous flush