### PR TITLE
Add `metadata` to gemspec

### DIFF
--- a/statsig.gemspec
+++ b/statsig.gemspec
@@ -10,6 +10,11 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://rubygems.org/gems/statsig'
   s.license     = 'ISC'
   s.files       = Dir['lib/**/*']
+  s.metadata    = {
+    "source_code_uri" => "https://github.com/statsig-io/ruby-sdk",
+    "documentation_uri" => "https://docs.statsig.com/server/rubySDK",
+    "bug_tracker_uri" => "https://github.com/statsig-io/ruby-sdk/issues"
+  }
   s.required_ruby_version = '>= 2.5.0'
   s.rubygems_version = '>= 2.5.0'
   s.add_development_dependency 'bundler', '~> 2.0'


### PR DESCRIPTION
We use dependabot to manage our dependencies and the Pull Requests bumping `statisg` dependency don't have any info on what changed on the gem:

<img width="919" alt="Screenshot 2024-09-27 at 11 18 58" src="https://github.com/user-attachments/assets/301786bd-7813-4c84-8106-9d5ab51cc448">

The `source_code_uri` should help dependabot to know about tags/releases/commits, and it will make it easier to reach this repo from the https://rubygems.org/gems/statsig page.