### PR TITLE
improve performance and memory usage in HashUtils.djb2

### DIFF
--- a/lib/hash_utils.rb
+++ b/lib/hash_utils.rb
@@ -7,8 +7,8 @@ module Statsig
   class HashUtils
     def self.djb2(input_str)
       hash = 0
-      input_str.each_char.each do |c|
-        hash = (hash << 5) - hash + c.ord
+      input_str.each_codepoint.each do |c|
+        hash = (hash << 5) - hash + c
         hash &= 0xFFFFFFFF
       end
       hash &= 0xFFFFFFFF # Convert to unsigned 32-bit integer

--- a/lib/hash_utils.rb
+++ b/lib/hash_utils.rb
@@ -9,7 +9,7 @@ module Statsig
       hash = 0
       input_str.each_char.each do |c|
         hash = (hash << 5) - hash + c.ord
-        hash &= hash
+        hash &= 0xFFFFFFFF
       end
       hash &= 0xFFFFFFFF # Convert to unsigned 32-bit integer
       return hash.to_s


### PR DESCRIPTION
Runtime profiling indicates this method generates several many memory allocations.

Comparing to the JS implementation, we saw the intent of the `hash &= hash` line was to force the JS runtime to keep the number as a 32-bit integer. This is indeed the correct way to do it in JS, but not in Ruby; as a result, the `hash` local will grow ever larger, requiring more and more memory since Ruby supports unbounded integers.

Fix: truncate the hash value on each iteration with the same 32-bit `0xFFFFFFF` constant used at the end instead.