### PR TITLE
gemspec: Unlock minor version of UAP

### DIFF
--- a/statsig.gemspec
+++ b/statsig.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov', '~> 0.21'
   s.add_development_dependency 'simplecov-lcov', '~> 0.7.0'
   s.add_development_dependency 'simplecov-cobertura', '~> 2.1'
-  s.add_runtime_dependency 'user_agent_parser', '~> 2.15.0'
+  s.add_runtime_dependency 'user_agent_parser', '~> 2.15'
   s.add_runtime_dependency 'http', '>= 4.4', '< 6.0'
   s.add_runtime_dependency 'connection_pool', '~> 2.4', '>= 2.4.1'
   s.add_runtime_dependency 'ip3country', '~> 0.2.1'


### PR DESCRIPTION
I don't see reason to lock on specific minor. The only breaking change UAP introduced in 2.20 was drop of ruby < 3.0, but that should not break anything for statsig.