### PR TITLE
Fix zlib dependency conflict with Ruby 3.4

### DIFF
--- a/statsig.gemspec
+++ b/statsig.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'connection_pool', '~> 2.4', '>= 2.4.1'
   s.add_runtime_dependency 'ip3country', '~> 0.2.1'
   s.add_runtime_dependency 'concurrent-ruby', '~> 1.1'
-  s.add_runtime_dependency 'zlib', '~> 3.1.0'
+  s.add_runtime_dependency 'zlib', '>= 3.1', '< 4.0'
 end


### PR DESCRIPTION
Ruby 3.4 ships with zlib 3.2.1 pre-activated as a bundled gem. The current constraint `~> 3.1.0` only allows up to < 3.2.0, causing an activation conflict on Ruby 3.4 and AWS Lambda Ruby 3.4 runtimes.

Loosening to `>= 3.1, < 4.0` resolves this while still guarding against potential major version breaking changes.

o library code is modified. The zlib 3.x API is fully backwards
compatible so no existing tests should be affected.

Fixes #39 