### PR TITLE
Add allocated_experiment attribute to Layer class

### DIFF
--- a/lib/layer.rb
+++ b/lib/layer.rb
@@ -13,6 +13,8 @@ class Layer
 
   attr_accessor :group_name
 
+  attr_accessor :allocated_experiment
+
   def initialize(name, value = {}, rule_id = '', group_name = nil, allocated_experiment = nil, exposure_log_func = nil)
     @name = name
     @value = value || {}


### PR DESCRIPTION
Add allocated_experiment attribute to Layer class

Useful for getting the experiment name without using `layer.instance_variable_get(:@allocated_experiment)`